### PR TITLE
Run rehash command in the background

### DIFF
--- a/libexec/scalaenv-init
+++ b/libexec/scalaenv-init
@@ -102,7 +102,7 @@ if [ -r "$completion" ]; then
 fi
 
 if [ -z "${no_rehash}" ]; then
-  echo 'command scalaenv rehash 2>/dev/null'
+  echo '(command scalaenv rehash 2>/dev/null &)'
 fi
 
 commands=(`scalaenv-commands --sh`)

--- a/test/init.bats
+++ b/test/init.bats
@@ -14,7 +14,7 @@ load test_helper
 @test "auto rehash" {
   run scalaenv-init -
   assert_success
-  assert_line "command scalaenv rehash 2>/dev/null"
+  assert_line "(command scalaenv rehash 2>/dev/null &)"
 }
 
 @test "detect parent shell" {


### PR DESCRIPTION
The rehash command doesn't take too long to run, but can add up when
several *env projects (rbenv, pyenv, nodenv, etc) are installed at the
same time. This makes it run in the background so that you don't have
to skip it altogether (using the `--no-rehash` flag) but also don't
have to wait a lot during shell initialization.

The `()` around the command prevent it from displaying the job number
or the "job done" message once it finishes.