### PR TITLE
#55 can't execute on fish-shell

### DIFF
--- a/libexec/scalaenv-init
+++ b/libexec/scalaenv-init
@@ -102,7 +102,14 @@ if [ -r "$completion" ]; then
 fi
 
 if [ -z "${no_rehash}" ]; then
-  echo '(command scalaenv rehash 2>/dev/null &)'
+  case "$shell" in
+    fish )
+      echo 'true (command scalaenv rehash 2>/dev/null &)'
+      ;;
+    * )
+      echo '(command scalaenv rehash 2>/dev/null &)'
+      ;;
+  esac
 fi
 
 commands=(`scalaenv-commands --sh`)

--- a/test/init.bats
+++ b/test/init.bats
@@ -12,9 +12,15 @@ load test_helper
 }
 
 @test "auto rehash" {
-  run scalaenv-init -
+  run scalaenv-init - bash
   assert_success
   assert_line "(command scalaenv rehash 2>/dev/null &)"
+}
+
+@test "auto rehash (fish)" {
+  run scalaenv-init - fish
+  assert_success
+  assert_line "true (command scalaenv rehash 2>/dev/null &)"
 }
 
 @test "detect parent shell" {


### PR DESCRIPTION
Hi!

After merge #55, "Illegal command name" error was occurred on fish-shell.
I will send a PR.

// I am not good at English, so please let me know if it's strange...
こんにちは。
#55のマージ以降、fishで"Illegal command name"エラーが起きていました。
プルリクエストを送ります。