### PR TITLE
Fix scalaenv-install

### DIFF
--- a/plugins/scala-install/bin/scalaenv-install
+++ b/plugins/scala-install/bin/scalaenv-install
@@ -63,7 +63,7 @@ usage () {
 }
 
 definitions() {
-  ls -1 "$(abs_dirname $0/../../share/)"
+  ls -1 "$(abs_dirname $0)/../share/"
 }
 
 indent() {


### PR DESCRIPTION
scalaenv-install produces an error on `scalaenv install -l`

```bash
$ scalaenv install -l
Available versions:
/Users/tmshn/.anyenv/envs/scalaenv/plugins/scala-install/bin/scalaenv-install: line 51: cd: /Users/tmshn/.anyenv/envs/scalaenv/plugins/scala-install/bin/scalaenv-install/../../share: Not a directory
```

I fixed this.