### PR TITLE
dotty-0.21.0

### DIFF
--- a/plugins/scala-install/share/dotty-0.21.0
+++ b/plugins/scala-install/share/dotty-0.21.0
@@ -1,0 +1,4 @@
+sites=(
+    "https://github.com/lampepfl/dotty/releases/download/0.21.0"
+    );
+archive_file="dotty-0.21.0-RC1.tar.gz"


### PR DESCRIPTION
Yes, the weird naming of the archive that includes the "RC1" still is, in fact, really there.  I double-checked.