### PR TITLE
Add missing scala versions

### DIFF
--- a/plugins/scala-install/share/dotty-0.23.0
+++ b/plugins/scala-install/share/dotty-0.23.0
@@ -1,0 +1,4 @@
+sites=(
+    "https://github.com/lampepfl/dotty/releases/download/0.23.0"
+    );
+archive_file="dotty-0.23.0.tar.gz"

--- a/plugins/scala-install/share/dotty-0.24.0
+++ b/plugins/scala-install/share/dotty-0.24.0
@@ -1,0 +1,4 @@
+sites=(
+    "https://github.com/lampepfl/dotty/releases/download/0.24.0"
+    );
+archive_file="dotty-0.24.0.tar.gz"

--- a/plugins/scala-install/share/dotty-0.24.0-RC1
+++ b/plugins/scala-install/share/dotty-0.24.0-RC1
@@ -1,0 +1,4 @@
+sites=(
+    "https://github.com/lampepfl/dotty/releases/download/0.24.0-RC1"
+    );
+archive_file="dotty-0.24.0-RC1.tar.gz"

--- a/plugins/scala-install/share/dotty-0.25.0
+++ b/plugins/scala-install/share/dotty-0.25.0
@@ -1,0 +1,4 @@
+sites=(
+    "https://github.com/lampepfl/dotty/releases/download/0.25.0"
+    );
+archive_file="dotty-0.25.0.tar.gz"

--- a/plugins/scala-install/share/dotty-0.25.0-RC1
+++ b/plugins/scala-install/share/dotty-0.25.0-RC1
@@ -1,0 +1,4 @@
+sites=(
+    "https://github.com/lampepfl/dotty/releases/download/0.25.0-RC1"
+    );
+archive_file="dotty-0.25.0-RC1.tar.gz"

--- a/plugins/scala-install/share/dotty-0.25.0-RC2
+++ b/plugins/scala-install/share/dotty-0.25.0-RC2
@@ -1,0 +1,4 @@
+sites=(
+    "https://github.com/lampepfl/dotty/releases/download/0.25.0-RC2"
+    );
+archive_file="dotty-0.25.0-RC2.tar.gz"

--- a/plugins/scala-install/share/dotty-0.26.0
+++ b/plugins/scala-install/share/dotty-0.26.0
@@ -1,0 +1,4 @@
+sites=(
+    "https://github.com/lampepfl/dotty/releases/download/0.26.0"
+    );
+archive_file="dotty-0.26.0.tar.gz"

--- a/plugins/scala-install/share/dotty-0.26.0-RC1
+++ b/plugins/scala-install/share/dotty-0.26.0-RC1
@@ -1,0 +1,4 @@
+sites=(
+    "https://github.com/lampepfl/dotty/releases/download/0.26.0-RC1"
+    );
+archive_file="dotty-0.26.0-RC1.tar.gz"

--- a/plugins/scala-install/share/dotty-0.27.0-RC1
+++ b/plugins/scala-install/share/dotty-0.27.0-RC1
@@ -1,0 +1,4 @@
+sites=(
+    "https://github.com/lampepfl/dotty/releases/download/0.27.0-RC1"
+    );
+archive_file="dotty-0.27.0-RC1.tar.gz"

--- a/plugins/scala-install/share/scala-2.10.2-RC2
+++ b/plugins/scala-install/share/scala-2.10.2-RC2
@@ -1,0 +1,4 @@
+sites=(
+    "http://www.scala-lang.org/files/archive"
+    );
+archive_file="scala-2.10.2-RC2.tgz"

--- a/plugins/scala-install/share/scala-2.10.3-RC2
+++ b/plugins/scala-install/share/scala-2.10.3-RC2
@@ -1,0 +1,4 @@
+sites=(
+    "http://www.scala-lang.org/files/archive"
+    );
+archive_file="scala-2.10.3-RC2.tgz"

--- a/plugins/scala-install/share/scala-2.10.3-RC3
+++ b/plugins/scala-install/share/scala-2.10.3-RC3
@@ -1,0 +1,4 @@
+sites=(
+    "http://www.scala-lang.org/files/archive"
+    );
+archive_file="scala-2.10.3-RC3.tgz"

--- a/plugins/scala-install/share/scala-2.10.4-RC1
+++ b/plugins/scala-install/share/scala-2.10.4-RC1
@@ -1,0 +1,4 @@
+sites=(
+    "http://www.scala-lang.org/files/archive"
+    );
+archive_file="scala-2.10.4-RC1.tgz"

--- a/plugins/scala-install/share/scala-2.10.4-RC2
+++ b/plugins/scala-install/share/scala-2.10.4-RC2
@@ -1,0 +1,4 @@
+sites=(
+    "http://www.scala-lang.org/files/archive"
+    );
+archive_file="scala-2.10.4-RC2.tgz"

--- a/plugins/scala-install/share/scala-2.10.4-RC3
+++ b/plugins/scala-install/share/scala-2.10.4-RC3
@@ -1,0 +1,4 @@
+sites=(
+    "http://www.scala-lang.org/files/archive"
+    );
+archive_file="scala-2.10.4-RC3.tgz"

--- a/plugins/scala-install/share/scala-2.12.12
+++ b/plugins/scala-install/share/scala-2.12.12
@@ -1,0 +1,4 @@
+sites=(
+    "http://www.scala-lang.org/files/archive"
+    );
+archive_file="scala-2.12.12.tgz"

--- a/plugins/scala-install/share/scala-2.13.0-M3
+++ b/plugins/scala-install/share/scala-2.13.0-M3
@@ -1,0 +1,4 @@
+sites=(
+    "http://www.scala-lang.org/files/archive"
+    );
+archive_file="scala-2.13.0-M3.tgz"

--- a/plugins/scala-install/share/scala-2.13.0-M5
+++ b/plugins/scala-install/share/scala-2.13.0-M5
@@ -1,0 +1,4 @@
+sites=(
+    "http://www.scala-lang.org/files/archive"
+    );
+archive_file="scala-2.13.0-M5.tgz"

--- a/plugins/scala-install/share/scala-2.13.0-RC2
+++ b/plugins/scala-install/share/scala-2.13.0-RC2
@@ -1,0 +1,4 @@
+sites=(
+    "http://www.scala-lang.org/files/archive"
+    );
+archive_file="scala-2.13.0-RC2.tgz"

--- a/plugins/scala-install/share/scala-2.13.0-RC3
+++ b/plugins/scala-install/share/scala-2.13.0-RC3
@@ -1,0 +1,4 @@
+sites=(
+    "http://www.scala-lang.org/files/archive"
+    );
+archive_file="scala-2.13.0-RC3.tgz"

--- a/plugins/scala-install/share/scala3-3.0.0-M1
+++ b/plugins/scala-install/share/scala3-3.0.0-M1
@@ -1,0 +1,5 @@
+sites=(
+    "https://github.com/lampepfl/dotty/releases/download/3.0.0-M1"
+    );
+archive_file="scala3-3.0.0-M1.tar.gz"
+

--- a/plugins/scala-install/share/scala3-3.0.0-M2
+++ b/plugins/scala-install/share/scala3-3.0.0-M2
@@ -1,0 +1,5 @@
+sites=(
+    "https://github.com/lampepfl/dotty/releases/download/3.0.0-M2"
+    );
+archive_file="scala3-3.0.0-M2.tar.gz"
+

--- a/plugins/scala-install/share/scala3-3.0.0-M3
+++ b/plugins/scala-install/share/scala3-3.0.0-M3
@@ -1,0 +1,5 @@
+sites=(
+    "https://github.com/lampepfl/dotty/releases/download/3.0.0-M3"
+    );
+archive_file="scala3-3.0.0-M3.tar.gz"
+


### PR DESCRIPTION
Added the following:
- dotty-0.23.0
- dotty-0.24.0
- dotty-0.24.0-RC1
- dotty-0.25.0
- dotty-0.25.0-RC1
- dotty-0.25.0-RC2
- dotty-0.26.0
- dotty-0.26.0-RC1
- dotty-0.27.0-RC1
- scala-2.10.2-RC2
- scala-2.10.3-RC2
- scala-2.10.3-RC3
- scala-2.10.4-RC1
- scala-2.10.4-RC2
- scala-2.10.4-RC3
- scala-2.12.12
- scala-2.13.0-M3
- scala-2.13.0-M5
- scala-2.13.0-RC2
- scala-2.13.0-RC3
- scala3-3.0.0-M1
- scala3-3.0.0-M2
- scala3-3.0.0-M3