### PR TITLE
Add scala-2.13.5 and scala3-3.0.0-RC1

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ $ brew upgrade --fetch-HEAD scalaenv
 
 ### Version History
 
+**0.1.9** (Feb, 23, 2021)
+  - Added version **2.13.5** and **3.0.0-RC1**
+  - [diff](https://github.com/scalaenv/scalaenv/compare/version/0.1.8...version/0.1.9)
+
 **0.1.8** (Feb, 12, 2021)
   - Fix urls for 2.7.0 and 2.7.1
   - [diff](https://github.com/scalaenv/scalaenv/compare/version/0.1.7...version/0.1.8)

--- a/plugins/scala-install/share/scala-2.13.5
+++ b/plugins/scala-install/share/scala-2.13.5
@@ -1,0 +1,4 @@
+sites=(
+    "http://www.scala-lang.org/files/archive"
+    );
+archive_file="scala-2.13.5.tgz"

--- a/plugins/scala-install/share/scala3-3.0.0-RC1
+++ b/plugins/scala-install/share/scala3-3.0.0-RC1
@@ -1,0 +1,5 @@
+sites=(
+    "https://github.com/lampepfl/dotty/releases/download/3.0.0-RC1"
+    );
+archive_file="scala3-3.0.0-RC1.tar.gz"
+


### PR DESCRIPTION
Add scala-2.13.5 and scala3-3.0.0-RC1

Checked download and install scala-2.13.5 and scala3-3.0.0-RC1 properly

in my machine (CentOS Linux release 7.6.1810 (Core)).

Confirm and merge pull request, please.

Thanks and Regards.

P.S.
Please also create a tag 0.1.9.