### PR TITLE
add version 2.13.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ $ brew upgrade --fetch-HEAD scalaenv
 
 ### Version History
 
+**0.1.13** (May, 17, 2021)
+  - Added version **2.13.6**
+  - [diff](https://github.com/scalaenv/scalaenv/compare/version/0.1.12...version/0.1.13)
+
 **0.1.12** (May, 13, 2021)
   - Added version **3.0.0**
   - [diff](https://github.com/scalaenv/scalaenv/compare/version/0.1.11...version/0.1.12)

--- a/plugins/scala-install/share/scala-2.13.6
+++ b/plugins/scala-install/share/scala-2.13.6
@@ -1,0 +1,4 @@
+sites=(
+    "http://www.scala-lang.org/files/archive"
+    );
+archive_file="scala-2.13.6.tgz"


### PR DESCRIPTION
Add scala-2.13.6

Checked download and install scala-2.13.6 properly

in my machine (CentOS Linux release 7.6.1810 (Core)).

Confirm and merge pull request, please.

Thanks and Regards.

P.S.
Please also create a tag 0.1.13.